### PR TITLE
Add tblib to the list of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ requires=[
     'ont_fast5_api',
     'pysam', 
     'pyslow5', 
-    'pod5'
+    'pod5',
+    'tblib'
 ],
 
 setup(


### PR DESCRIPTION
Hi! It seems that tblib is required (used in `src/uncalled4/__init__.py:17`), but is missing from the list of dependencies.