### PR TITLE
Delete memray import that can prevent running the align subcommand

### DIFF
--- a/src/uncalled4/align.py
+++ b/src/uncalled4/align.py
@@ -27,8 +27,6 @@ from _uncalled4 import ReadBuffer
 import multiprocessing as mp
 
 
-import memray
-
 
 #from concurrent.futures import ProcessPoolExecutor as Pool
 


### PR DESCRIPTION
Sorry about the small piecemeal pull requests! I wanted to add this to the previous PR, but you were super quick in merging it.