### PR TITLE
Add feature for load and slicing of split reads

### DIFF
--- a/src/uncalled4/io/bam.py
+++ b/src/uncalled4/io/bam.py
@@ -342,7 +342,11 @@ class BAM(TrackIO):
 
         aln = None
 
-        read = self.tracks.read_index[sam.query_name] #None)
+        if sam.has_tag("pi"): # splitted read, should have "sp".
+            read = self.tracks.read_index[sam.get_tag("pi")]
+            read = self.tracks.read_index.process_splitted_read(read, sam)
+        else:
+            read = self.tracks.read_index[sam.query_name] #None)
 
         if not has_dtw and read is None:
             return None


### PR DESCRIPTION
Hi, I'm currently working uncalled4 with direct RNA sequencing data basecalled with dorado 0.5.0

I encountered endless Warning messages which saying `failed to open read ####` during `uncalled4 align` with simple parameter:
```
uncalled4 align --bam-in input.bam reference.fa /fast5/dir -o output.bam
```
The run ended with following counter status:
```
Counter({'Success': 90691, 'Missing signal': 6696, 'Alignment too short': 133})
```

I think current uncalled4 couldn't load [dorado's split reads](https://github.com/nanoporetech/dorado/blob/release-v0.5.3/documentation/SAM.md#split-read-tags). I believe my work may be able to help supporting split read loading temporary.

I intended to re-declare ReadBuffer with trimmed signal when split read detected to prevent potential malfunction, which is inefficient way.

Somehow, my new run with modified version ended without any warning/error and no running time changes.
The new run's Counter status was:
```
Counter({'Success': 97123, 'Alignment too short': 397})
```

Please review my commit and consider merge if you are interested in.
Thanks.